### PR TITLE
fix: resolve header menu height

### DIFF
--- a/app/src/app/layout.tsx
+++ b/app/src/app/layout.tsx
@@ -18,7 +18,7 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: LayoutProps) {
     return (
         <html lang="en">
-            <body className={`${poppins.className} antialiased overflow-x-hidden bg-black`}>
+            <body className={`${poppins.className} antialiased relativ overflow-x-hidden bg-black`}>
                 <Header />
                 {children}
                 <Footer />

--- a/app/src/app/layout.tsx
+++ b/app/src/app/layout.tsx
@@ -18,7 +18,7 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: LayoutProps) {
     return (
         <html lang="en">
-            <body className={`${poppins.className} antialiased relativ overflow-x-hidden bg-black`}>
+            <body className={`${poppins.className} antialiased relative overflow-x-hidden bg-black`}>
                 <Header />
                 {children}
                 <Footer />

--- a/app/src/ui/header/header-menu.tsx
+++ b/app/src/ui/header/header-menu.tsx
@@ -5,23 +5,24 @@ import { itemVariants, menuVariants } from "../motion/menu.motion"
 export const HeaderMenu = () => {
 
     return (
-        <motion.aside 
-            className="w-10/12 max-w-md p-10 flex flex-col justify-evenly absolute inset-y-0 right-0 z-10 bg-[#161616]"
+        <motion.div className="w-10/12 max-w-md absolute inset-y-0 right-0 z-10 bg-[#161616]"
             variants={menuVariants}
             initial="hidden"
             animate="visible"
-            exit="exit"                
+            exit="exit"
         >
-            <p className="pb-1 border-b border-gray">Navigation</p>
-            <ul className="fluency-3xl font-medium flex flex-col gap-y-8">
-                <motion.li variants={itemVariants}><Link href="/">Home</Link></motion.li>
-                <motion.li variants={itemVariants}><Link href="/">Installation</Link></motion.li>
-                <motion.li variants={itemVariants}><Link href="/">About</Link></motion.li>
-            </ul>
-            <ul className="mt-10 flex items-center justify-around">
-                <li><Link href="https://github.com/halvaradop/tailwindcss-utilities" target="_blank">Github</Link></li>
-                <li><Link href="https://www.npmjs.com/package/@halvaradop/tailwindcss-utilities" target="_blank">NPM</Link></li>
-            </ul>
-        </motion.aside>
+            <aside className="min-h-dvh p-10 flex flex-col justify-evenly">
+                <p className="pb-1 border-b border-gray">Navigation</p>
+                <ul className="fluency-3xl font-medium flex flex-col gap-y-8">
+                    <motion.li variants={itemVariants}><Link href="/">Home</Link></motion.li>
+                    <motion.li variants={itemVariants}><Link href="/">Installation</Link></motion.li>
+                    <motion.li variants={itemVariants}><Link href="/">Docs</Link></motion.li>
+                </ul>
+                <ul className="mt-10 flex items-center justify-around">
+                    <li><Link href="https://github.com/halvaradop/tailwindcss-utilities" target="_blank">Github</Link></li>
+                    <li><Link href="https://www.npmjs.com/package/@halvaradop/tailwindcss-utilities" target="_blank">NPM</Link></li>
+                </ul>
+            </aside>
+        </motion.div>
     )
 }


### PR DESCRIPTION
## Description
This pull request resolves an error in the header menu component related to the window height. Previously, the menu component used 100% of the window height, but now it correctly uses 100% of the relative document height.

## Checklist
- [ ]  Added documentation.
- [x]  The changes do not generate any warnings.
- [x]  I have performed a self-review of my own code
- [ ]  All tests have been added and pass successfully

## Notes
<!-- Add any additional relevant information here -->