### PR TITLE
fix: correct min-width utility implementation

### DIFF
--- a/src/utilities/min-width-utility.ts
+++ b/src/utilities/min-width-utility.ts
@@ -6,12 +6,14 @@ import { Config } from "tailwindcss";
  */
 export const minWidthUtilities: Partial<Config> = {
     theme: {
-        minWidth: {
-            sm: "640px",
-            md: "768px",
-            lg: "1024px",
-            xl: "1280px",
-            "2xl": "1526px"
+        extend: {
+            minWidth: {
+                sm: "640px",
+                md: "768px",
+                lg: "1024px",
+                xl: "1280px",
+                "2xl": "1526px"
+            }
         }
     }
 }


### PR DESCRIPTION
## Description
This pull request fixes an issue in the min-width utility implementation. The utility has been properly integrated into the `extend` property of the Tailwind CSS configuration file. This correction ensures that the utility behaves as expected, resolves previous issues, and does not overwrite the default min-width utility classes defined by Tailwind CSS.

## Checklist
- [ ]  Added documentation.
- [x]  The changes do not generate any warnings.
- [x]  I have performed a self-review of my own code
- [ ]  All tests have been added and pass successfully

## Notes
<!-- Add any additional relevant information here -->