### PR TITLE
chore: add `type` keyword to type imports

### DIFF
--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -1,5 +1,5 @@
 import plugin from "tailwindcss/plugin"
-import { KeyValuePair, PluginCreator, ResolvableTo } from "tailwindcss/types/config"
+import { PluginCreator } from "tailwindcss/types/config"
 import { scrollUtilities } from "./utilities/scroll-utility"
 import { fluencyUtilities } from "./utilities/fluency-utility"
 import { selectorUtilities } from "./utilities/selector-utility"

--- a/packages/plugin/src/utilities/fluency-utility.ts
+++ b/packages/plugin/src/utilities/fluency-utility.ts
@@ -1,5 +1,5 @@
-import { PluginAPI } from "tailwindcss/types/config"
-import { EntryCSS, FontFluency } from "../types"
+import type { PluginAPI } from "tailwindcss/types/config"
+import type { EntryCSS, FontFluency } from "../types"
 import { removeEmptyProperties } from "../utils/utils"
 
 /**

--- a/packages/plugin/src/utilities/pseudo-classes-utility.ts
+++ b/packages/plugin/src/utilities/pseudo-classes-utility.ts
@@ -1,4 +1,4 @@
-import { PluginAPI } from "tailwindcss/types/config"
+import type { PluginAPI } from "tailwindcss/types/config"
 
 /**
  * Defines a set of variant utilities for grouping elements and customizing

--- a/packages/plugin/src/utilities/scroll-utility.ts
+++ b/packages/plugin/src/utilities/scroll-utility.ts
@@ -1,4 +1,4 @@
-import { PluginAPI } from "tailwindcss/types/config"
+import type { PluginAPI } from "tailwindcss/types/config"
 
 /**
  * Defines a set of variants to customize the scrollbar of a component or

--- a/packages/plugin/src/utilities/selector-utility.ts
+++ b/packages/plugin/src/utilities/selector-utility.ts
@@ -1,4 +1,4 @@
-import { PluginAPI } from "tailwindcss/types/config"
+import type { PluginAPI } from "tailwindcss/types/config"
 import { verifySelectorsTheme } from "../utils/utils"
 
 /**


### PR DESCRIPTION
## Description
This pull request introduces changes across the codebase by adding the type keyword to all type-only imports in various files. The purpose of these changes is to ensure that only types are imported from files, preventing unnecessary imports of other code and improving overall performance and readability.

## Checklist
- [ ]  Added documentation.
- [x]  The changes do not generate any warnings.
- [x]  I have performed a self-review of my own code
- [ ]  All tests have been added and pass successfully

## Notes
<!-- Add any additional relevant information here -->