### PR TITLE
test: add unit tests for scroll utilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   },
   "homepage": "https://github.com/halvaradop/tailwindcss-utilities#readme",
   "devDependencies": {
+    "@csstools/postcss-minify": "^2.0.1",
     "@types/node": "^22.5.4",
     "autoprefixer": "^10.4.19",
     "postcss": "^8.4.45",

--- a/packages/plugin/test/index.test.ts
+++ b/packages/plugin/test/index.test.ts
@@ -32,7 +32,7 @@ describe("scroll utilities", () => {
         expect(css).toContain(".track\\:border::-webkit-scrollbar-track{border-width:1px}")
     })
 
-    test.concurrent("generate the css for scroll track utilities with custom background color", async ({ expect }) => {
+    test.concurrent("generate the css for scroll track utilities with custom border width", async ({ expect }) => {
         const html = `<div class="track:border-[3px]"></div>`
         const css = await generateClasses(html)
         expect(css).toContain(".track\\:border-\\[3px\\]::-webkit-scrollbar-track{border-width:3px}")

--- a/packages/plugin/test/index.test.ts
+++ b/packages/plugin/test/index.test.ts
@@ -1,2 +1,40 @@
-import { describe, test, expect } from "vitest"
+import { describe, test } from "vitest"
 import { generateClasses } from "./utils"
+
+describe("scroll utilities", () => {
+    test.concurrent("generate the css for scroll utilities", async ({ expect }) => {
+        const html = `<div class="scroll:w-2"></div>`
+        const css = await generateClasses(html)
+        expect(css).toContain(".scroll\\:w-2::-webkit-scrollbar{width:0.5rem}")
+    })
+
+    test.concurrent("generate the css for scroll utilities with custom width", async ({ expect }) => {
+        const html = `<div class="scroll:w-[10px]"></div>`
+        const css = await generateClasses(html)
+        expect(css).toContain(".scroll\\:w-\\[10px\\]::-webkit-scrollbar{width:10px}")
+    })
+
+    test.concurrent("generate the css for scroll thumb utilities", async ({ expect }) => {
+        const html = `<div class="thumb:my-4"></div>`
+        const css = await generateClasses(html)
+        expect(css).toContain(".thumb\\:my-4::-webkit-scrollbar-thumb{margin-top:1rem;margin-bottom:1rem}")
+    })
+
+    test.concurrent("generate the css for scroll thumb utilities with custom margin", async ({ expect }) => {
+        const html = `<div class="thumb:my-[8px]"></div>`
+        const css = await generateClasses(html)
+        expect(css).toContain(".thumb\\:my-\\[8px\\]::-webkit-scrollbar-thumb{margin-top:8px;margin-bottom:8px}")
+    })
+
+    test.concurrent("generate the css for scroll track utilities", async ({ expect }) => {
+        const html = `<div class="track:border"></div>`
+        const css = await generateClasses(html)
+        expect(css).toContain(".track\\:border::-webkit-scrollbar-track{border-width:1px}")
+    })
+
+    test.concurrent("generate the css for scroll track utilities with custom background color", async ({ expect }) => {
+        const html = `<div class="track:border-[3px]"></div>`
+        const css = await generateClasses(html)
+        expect(css).toContain(".track\\:border-\\[3px\\]::-webkit-scrollbar-track{border-width:3px}")
+    })
+})

--- a/packages/plugin/test/utils.ts
+++ b/packages/plugin/test/utils.ts
@@ -1,6 +1,7 @@
 import postcss from "postcss"
 import tailwindcss from "tailwindcss"
 import plugin from "../src/index"
+import minify from "@csstools/postcss-minify"
 
 const TAILWIND_UTILITIES_DIRECTIVE = "@tailwind utilities;"
 
@@ -17,6 +18,7 @@ const TAILWIND_UTILITIES_DIRECTIVE = "@tailwind utilities;"
  */
 export const generateClasses = async (htmlContent: string) => {
     const classes = await postcss([
+        minify(),
         tailwindcss({
             plugins: [plugin],
             content: [{ raw: htmlContent }],


### PR DESCRIPTION
## Description
This pull request adds unit tests for scroll utilities, focusing on their three main classes: `scroll`, `thumb`, and `track`, which are used to customize the scrollbar. Additionally, it includes the installation of the `minify` package to enhance the testing process and help ensure accuracy in matching the classes with their expected behavior.

## Checklist
- [x]  Added documentation.
- [x]  The changes do not generate any warnings.
- [x]  I have performed a self-review of my own code
- [x]  All tests have been added and pass successfully

## Notes
<!-- Add any additional relevant information here -->