### PR TITLE
chore: add `--if-present` flag and remove `npx` from prettier commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,12 +4,12 @@
   "version": "0.0.0",
   "description": "A monorepo projectmanage multiple packages with features and utilities for TailwindCSS.",
   "scripts": {
-    "build:watch": "npm run build:watch --workspaces",
-    "build": "npm run build --workspaces",
-    "format": "npx prettier --write .",
-    "format:check": "npx prettier --check .",
-    "test": "npm run test --workspaces",
-    "test:watch": "npm run test:watch --workspaces"
+    "build:watch": "npm run build:watch --workspaces --if-present",
+    "build": "npm run build --workspaces --if-present",
+    "format": "prettier --write .",
+    "format:check": "prettier --check .",
+    "test": "npm run test --workspaces --if-present --silent",
+    "test:watch": "npm run test:watch --workspaces --if-present"
   },
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
## Description
This PR adds the `--if-present` flag to commands that run scripts across all packages. This change ensures that commands are skipped for packages lacking the specified script, preventing potential errors from missing scripts. Additionally, the `npx` prefix has been removed from the scripts that run Prettier.

## Checklist
- [ ]  Added documentation.
- [ ]  The changes do not generate any warnings.
- [ ]  I have performed a self-review of my own code
- [ ]  All tests have been added and pass successfully

## Notes
<!-- Add any additional relevant information here -->