### PR TITLE
chore: clean up `exports` fields in packages

### DIFF
--- a/packages/tailwindcss-animations/package.json
+++ b/packages/tailwindcss-animations/package.json
@@ -3,7 +3,6 @@
   "version": "0.1.0",
   "description": "A collection of utility classes and utilities for animations using Tailwind CSS",
   "type": "module",
-  "main": "dist/index.js",
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",
@@ -32,6 +31,13 @@
   "homepage": "https://github.com/halvaradop/tailwindcss-utilities#readme",
   "devDependencies": {
     "@halvaradop/tailwindcss-animations": "^0.1.0"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
   },
   "files": [
     "dist"

--- a/packages/tailwindcss-core/src/index.ts
+++ b/packages/tailwindcss-core/src/index.ts
@@ -1,8 +1,9 @@
-import { defineConfig } from "tsup"
+import { Options } from "tsup"
 
-type TsupConfig = Parameters<typeof defineConfig>[0]
-
-export const tsupConfig: TsupConfig = {
+/**
+ * Base tsup configuration for the package.
+ */
+export const tsupConfig: Options = {
     entry: ["src"],
     format: ["esm", "cjs"],
     dts: true,

--- a/packages/tailwindcss-utilities/package.json
+++ b/packages/tailwindcss-utilities/package.json
@@ -3,8 +3,6 @@
   "version": "0.2.1",
   "description": "A TailwindCSS plugin that provides a set of utilities to enhance the default functionalities and offer additional customization options.",
   "type": "module",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",
@@ -36,6 +34,13 @@
   "homepage": "https://github.com/halvaradop/tailwindcss-utilities#readme",
   "devDependencies": {
     "@halvaradop/tailwindcss-core": "^0.1.0"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
   },
   "files": [
     "dist"


### PR DESCRIPTION
## Description
This pull request cleans up the `exports` fields in the `package.json` files of various packages, ensuring only the necessary files and directories are accessible to users. The changes aim to improve the clarity and structure of the packages, limiting exposure to internal or unnecessary code, and providing users with just the essential utilities.

## Checklist
- [ ]  Added documentation.
- [x]  The changes do not generate any warnings.
- [x]  I have performed a self-review of my own code
- [ ]  All tests have been added and pass successfully

## Notes
<!-- Add any additional relevant information here -->