### PR TITLE
fix: remove redundant self-referencing package dependency

### DIFF
--- a/packages/tailwindcss-animations/package.json
+++ b/packages/tailwindcss-animations/package.json
@@ -30,7 +30,7 @@
   },
   "homepage": "https://github.com/halvaradop/tailwindcss-utilities#readme",
   "devDependencies": {
-    "@halvaradop/tailwindcss-animations": "^0.1.0"
+    "@halvaradop/tailwindcss-core": "^0.1.0"
   },
   "exports": {
     ".": {


### PR DESCRIPTION
## Description
This pull request fixes the redundant self-referencing issue in the `tailwindcss-animations` package, which was causing deployment and publishing errors. The dependency on the `animations` package has been replaced with a reference to the `core` package to resolve these issues and streamline the package structure.

## Checklist
- [ ]  Added documentation.
- [x]  The changes do not generate any warnings.
- [x]  I have performed a self-review of my own code
- [ ]  All tests have been added and pass successfully

## Notes
<!-- Add any additional relevant information here -->