### PR TITLE
chore: update test to use `toMatch` instead of `toContain`

### DIFF
--- a/packages/tailwindcss-utilities/test/index.test.ts
+++ b/packages/tailwindcss-utilities/test/index.test.ts
@@ -1,6 +1,6 @@
 import { describe, test } from "vitest"
 import { extractClasses } from "@halvaradop/tailwindcss-core/utils"
-import plugin from "../src/index"
+import plugin from "../src"
 
 const generateClasses = extractClasses(plugin)
 
@@ -8,36 +8,36 @@ describe("scroll utilities", () => {
     test.concurrent("generate the css for scroll utilities", async ({ expect }) => {
         const html = `<div class="scroll:w-2"></div>`
         const css = await generateClasses(html)
-        expect(css).toContain(".scroll\\:w-2::-webkit-scrollbar{width:0.5rem}")
+        expect(css).toMatch(".scroll\\:w-2::-webkit-scrollbar{width:0.5rem}")
     })
 
     test.concurrent("generate the css for scroll utilities with custom width", async ({ expect }) => {
         const html = `<div class="scroll:w-[10px]"></div>`
         const css = await generateClasses(html)
-        expect(css).toContain(".scroll\\:w-\\[10px\\]::-webkit-scrollbar{width:10px}")
+        expect(css).toMatch(".scroll\\:w-\\[10px\\]::-webkit-scrollbar{width:10px}")
     })
 
     test.concurrent("generate the css for scroll thumb utilities", async ({ expect }) => {
         const html = `<div class="thumb:my-4"></div>`
         const css = await generateClasses(html)
-        expect(css).toContain(".thumb\\:my-4::-webkit-scrollbar-thumb{margin-top:1rem;margin-bottom:1rem}")
+        expect(css).toMatch(".thumb\\:my-4::-webkit-scrollbar-thumb{margin-top:1rem;margin-bottom:1rem}")
     })
 
     test.concurrent("generate the css for scroll thumb utilities with custom margin", async ({ expect }) => {
         const html = `<div class="thumb:my-[8px]"></div>`
         const css = await generateClasses(html)
-        expect(css).toContain(".thumb\\:my-\\[8px\\]::-webkit-scrollbar-thumb{margin-top:8px;margin-bottom:8px}")
+        expect(css).toMatch(".thumb\\:my-\\[8px\\]::-webkit-scrollbar-thumb{margin-top:8px;margin-bottom:8px}")
     })
 
     test.concurrent("generate the css for scroll track utilities", async ({ expect }) => {
         const html = `<div class="track:border"></div>`
         const css = await generateClasses(html)
-        expect(css).toContain(".track\\:border::-webkit-scrollbar-track{border-width:1px}")
+        expect(css).toMatch(".track\\:border::-webkit-scrollbar-track{border-width:1px}")
     })
 
     test.concurrent("generate the css for scroll track utilities with custom border width", async ({ expect }) => {
         const html = `<div class="track:border-[3px]"></div>`
         const css = await generateClasses(html)
-        expect(css).toContain(".track\\:border-\\[3px\\]::-webkit-scrollbar-track{border-width:3px}")
+        expect(css).toMatch(".track\\:border-\\[3px\\]::-webkit-scrollbar-track{border-width:3px}")
     })
 })


### PR DESCRIPTION
## Description
This pull request updates the test functions to use `toMatch` instead of `toContain` for comparing the classes generated by the utilities provided by the plugin. This change enhances the tests by ensuring that the expected output matches all the classes defined in the test, leading to more accurate validation.


## Checklist
- [ ]  Added documentation.
- [x]  The changes do not generate any warnings.
- [x]  I have performed a self-review of my own code
- [ ]  All tests have been added and pass successfully

## Notes
<!-- Add any additional relevant information here -->