### PR TITLE
chore: add cleanup scripts to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,12 +6,15 @@
   "description": "A monorepo project for managing multiple packages with features and utilities for TailwindCSS.",
   "scripts": {
     "dev": "turbo dev --parallel",
-    "build": "turbo build --filter @halvaradop/*core && turbo build --filter=!@halvaradop/*core --parallel",
+    "build": "turbo build --filter *core && turbo build --filter=!*core --parallel",
     "format": "prettier --cache --write .",
     "format:check": "prettier --cache --check .",
     "test": "turbo test --parallel",
     "test:watch": "turbo test:watch --parallel",
-    "test:coverage": "vitest --coverage"
+    "test:coverage": "vitest --coverage",
+    "clean": "turbo clean --parallel",
+    "clean:dist": "turbo clean:dist --parallel",
+    "clean:modules": "turbo clean:modules --parallel"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/tailwindcss-animations/package.json
+++ b/packages/tailwindcss-animations/package.json
@@ -7,7 +7,10 @@
     "build": "tsup",
     "dev": "tsup --watch",
     "test": "vitest --run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "clean": "npm run clean:dist && npm run clean:modules",
+    "clean:dist": "rm -rf dist",
+    "clean:modules": "rm -rf node_modules"
   },
   "repository": {
     "type": "git",

--- a/packages/tailwindcss-core/package.json
+++ b/packages/tailwindcss-core/package.json
@@ -7,7 +7,10 @@
     "build": "tsup",
     "dev": "tsup --watch",
     "test": "vitest --run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "clean": "npm run clean:dist && npm run clean:modules",
+    "clean:dist": "rm -rf dist",
+    "clean:modules": "rm -rf node_modules"
   },
   "repository": {
     "type": "git",

--- a/packages/tailwindcss-utilities/package.json
+++ b/packages/tailwindcss-utilities/package.json
@@ -7,7 +7,10 @@
     "build": "tsup",
     "dev": "tsup --watch",
     "test": "vitest --run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "clean": "npm run clean:dist && npm run clean:modules",
+    "clean:dist": "rm -rf dist",
+    "clean:modules": "rm -rf node_modules"
   },
   "publishConfig": {
     "access": "public",

--- a/turbo.json
+++ b/turbo.json
@@ -17,6 +17,15 @@
     "test:watch": {
       "cache": false,
       "inputs": ["test"]
+    },
+    "clean": {
+      "cache": false
+    },
+    "clean:dist": {
+      "cache": false
+    },
+    "clean:modules": {
+      "cache": false
     }
   },
   "cacheDir": ".turbo/cache"


### PR DESCRIPTION


## Description
This pull request adds new cleanup scripts in package.json to streamline the build process by clearing out old build files and dependencies. These additions help maintain a clean project environment.

- Add `clean:build` to remove `dist` folder
- Add `clean:modules` to remoe `node_modules` folder
- Add `clean` to join `clean:build` and `clean:modules`

## Checklist
- [ ]  Added documentation.
- [x]  The changes do not generate any warnings.
- [x]  I have performed a self-review of my own code
- [x]  All tests have been added and pass successfully

## Notes
<!-- Add any additional relevant information here -->